### PR TITLE
SV-9970 Add Support for Azure AD Multi-Tenant as an Identity Provider

### DIFF
--- a/Source/AppAuthCore/OIDAuthorizationService.m
+++ b/Source/AppAuthCore/OIDAuthorizationService.m
@@ -563,6 +563,19 @@ NS_ASSUME_NONNULL_BEGIN
       // OpenID Connect Core Section 3.1.3.7. rule #2
       // Validates that the issuer in the ID Token matches that of the discovery document.
       NSURL *issuer = tokenResponse.request.configuration.issuer;
+
+      // from: https://github.com/openid/AppAuth-iOS/pull/714/files
+      if (issuer && [issuer.path containsString:@"{tenantid}"]) {
+        // The Azure AD discovery document's "issuer" value contains the special placeholder
+        // "{tenantid}". This needs to be replaced with the actual tenant ID of the authenticated
+        // user, from the "tid" claim of the ID token, before validation.
+        NSString *tid = idToken.claims[@"tid"];
+        if (tid) {
+          issuer = [NSURL URLWithString:[NSString stringWithFormat:@"%@://%@%@", issuer.scheme, issuer.host,
+                                         [issuer.path stringByReplacingOccurrencesOfString:@"{tenantid}" withString:tid]]];
+        }
+      }
+
       if (issuer && ![idToken.issuer isEqual:issuer]) {
         NSError *invalidIDToken =
           [OIDErrorUtilities errorWithCode:OIDErrorCodeIDTokenFailedValidationError

--- a/Source/AppAuthCore/OIDServiceDiscovery.m
+++ b/Source/AppAuthCore/OIDServiceDiscovery.m
@@ -106,6 +106,17 @@ static NSString *const kOPTosURIKey = @"op_tos_uri";
     return nil;
   }
 
+  // from: https://github.com/openid/AppAuth-iOS/pull/714/files
+  NSString *issuer = (NSString *) json[@"issuer"];
+  if (issuer && [issuer containsString:@"{tenantid}"]) {
+    // The Azure AD discovery document's "issuer" value contains the special placeholder
+    // "{tenantid}". '{' and '}' are invalid characters in URLs and have to be URL encoded before
+    // the issuer URL can be parsed by NSURL.
+    NSMutableDictionary *newJson = [NSMutableDictionary dictionaryWithDictionary:json];
+    newJson[@"issuer"] = [issuer stringByReplacingOccurrencesOfString:@"{tenantid}" withString:@"%7Btenantid%7D"];
+    json = newJson;
+  }
+
   return [self initWithDictionary:json error:error];
 }
 


### PR DESCRIPTION
Added code to account for Azure Multi-Tenant configuration. Code is from an un-merged PR on the main project GitHub repo: https://github.com/openid/AppAuth-iOS/pull/714/files The project owner seems unwilling to merge this change on the basis that a work-around is perceived to exist, and not because of any stated objection to the code. In my eyes, adding this code appears to be the best solution.

- [ ] 1. Verify that Jira ticket number is included in commit message using the standard format: [Project|]Ticket: <summary>

- [ ] 2. Verify that base branch matches Fix Version in Jira ticket

- [ ] 3. Verify that unit tests were added to cover new/modified code

- [ ] 4. Review for correctness, security (e.g. OWASP, conformance with AMN security standards, etc.), coding standards compliance, and style

- [ ] 5. Review for proper error handling and an acceptable level of operational logging

- [ ] 6. If changes are needed, assign the Jira ticket back to the developer and set status to “In Progress”

- [ ] 7. Merge PR when all issues/comments have been addressed

- [ ] 8. Verify that the correct Lead Developer is assigned on Jira ticket

- [ ] 9. Verify that a comment has been added to the Jira ticket that summarizes the work done in the PR

- [ ] 10. Verify that QA testing instructions are in the Jira ticket comments, if required

- [ ] 11. Verify that deployment steps have been added to the implementation plan, if required

- [ ] 12. Set status to Awaiting Deployment on Jira ticket (for BE and Web ticket assign to DevOps for deployment)
